### PR TITLE
Taught multiwatch to send the correct signal when using --signal

### DIFF
--- a/multiwatch.c
+++ b/multiwatch.c
@@ -94,7 +94,7 @@ static gint signame2num(const char *name) {
 
 	for (i = 0; signal_actions[i].signame; i++) {
 		if (0 == strcmp(signal_actions[i].signame, name)) {
-			return i;
+			return signal_actions[i].signum;
 		}
 	}
 


### PR DESCRIPTION
When the --signal flag was enabled, multiwatch was sending the
index of signal in the sig_actions array instead of the correct
signal number. So, when multiwatch was told to send a SIGTERM,
the application was actually being sent a SIGQUIT, which caused
the application to coredump as ordered.

The fix is to change the loop to return the signal number
stored at the index.

This is the first time I've contributed to a project. Sorry if 
I missed something.